### PR TITLE
Changed library for bng conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ in order to run the interface, I recommend the fantastic
 [uv package manager](https://docs.astral.sh/uv),
 which can be used to run the API directly with:
 ```shell
-uv run open_bus_api
+  uv run open_bus_api
 ```
 
+## Dependencies
+
+- [Flask API](https://flask.palletsprojects.com/en/stable/) - API framework
+- [Pandas](https://pandas.pydata.org) - Converting XML data to SQL
+- [Polars](https://pola.rs) - Querying databases
+- [BNG-latlon](https://github.com/fmalina/blocl-bnglatlon) - Converting British National Grid coordinates to Latitude and longitude
+- [xmlschema](https://xmlschema.readthedocs.io/en/latest/index.html) - Verifying XML data
+- [jsonschema](https://github.com/python-jsonschema/jsonschema) - Verifying JSON data
+- [jsonschema-default](https://github.com/mnboos/jsonschema-default) - For creating a default object from a JSON schema
+- [toml](https://github.com/uiri/toml) - For parsing TOML files

--- a/api_database/stop_database_setup.py
+++ b/api_database/stop_database_setup.py
@@ -4,7 +4,7 @@ import sqlite3
 import requests
 
 import polars as pl
-from convertbng.util import convert_lonlat
+from bng_latlon import OSGB36toWGS84 as convert_bng_to_latlon
 
 
 def fetch_stops_file(url: str, file: str):
@@ -25,7 +25,7 @@ def fetch_stops_file(url: str, file: str):
             f.write(chunk)
 
 
-def convert_bng(easting, northing):
+def convert_bng(easting, northing) -> tuple[float, float]:
     """
     Converts the BNG format to Longitude/Latitude
 
@@ -33,11 +33,10 @@ def convert_bng(easting, northing):
         easting (int): Easting
         northing (int): Northing
 
-    Returns: Longitude and Latitude as a list
+    Returns: Longitude and Latitude as a pair
 
     """
-    result = convert_lonlat([easting], [northing])
-    return [*result[0], *result[1]]
+    return convert_bng_to_latlon(easting, northing)
 
 
 def setup_stop_database(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "openBusAPI"
 description = "A Python API interface for the open Bus service API"
 requires-python = ">= 3.10"
 authors = [{ name = "Z M Williams", email = "z.m.will@icloud.com" }]
-version = "0.4.1"
+version = "0.4.2"
 readme = "README.md"
 license = { file = "LICENSE" }
 dependencies = [
@@ -20,8 +20,9 @@ dependencies = [
     "jsonschema-default>=1.8.1",
     "pyarrow>=20.0.0",
     "toml>=0.10.2",
-    "convertbng>=0.7.5",
     "jsonschema>=4.23.0",
+    "bng-latlon>=1.1",
+    "numba>=0.61.2",
 ]
 keywords = ["Python", "API", "Flask", "OpenBus", "BusTracker"]
 classifiers = [


### PR DESCRIPTION
The `convertbng` library failed to compile on some systems, thus the dependence on it was not ideal. The code has been modified to use an alternative library `bng_latlon` instead. 