### PR TITLE
Moved numba to optional dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "openBusAPI"
 description = "A Python API interface for the open Bus service API"
 requires-python = ">= 3.10"
 authors = [{ name = "Z M Williams", email = "z.m.will@icloud.com" }]
-version = "0.4.2"
+version = "0.4.3"
 readme = "README.md"
 license = { file = "LICENSE" }
 dependencies = [
@@ -21,8 +21,7 @@ dependencies = [
     "pyarrow>=20.0.0",
     "toml>=0.10.2",
     "jsonschema>=4.23.0",
-    "bng-latlon>=1.1",
-    "numba>=0.61.2",
+    "bng-latlon>=1.1"
 ]
 keywords = ["Python", "API", "Flask", "OpenBus", "BusTracker"]
 classifiers = [
@@ -45,6 +44,9 @@ dev = [
     "coverage>=7.8.0",
     "ruff>=0.11.8",
     "beautifulsoup4>=4.13.4",
+]
+numba = [
+    "numba>=0.61.2",
 ]
 doc = [
     "sphinx>=7.3.7",


### PR DESCRIPTION
It is not always possible to use `numba` with `bng-latlon`, so the library has been moved to optional dependencies.